### PR TITLE
Replace all the string templating with models of the configuration sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 build/
 dist/
 /.tox/
+.coverage
+htmlcov/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,24 +5,6 @@
 1.0.0a2 (unreleased)
 ====================
 
-- Nothing changed yet.
-
-
-1.0.0a1 (2019-11-14)
-====================
-
-- Fix relstorage recipe on Python 3. See `issue 8
-  <https://github.com/NextThought/nti.recipes.zodb/issues/8>`_.
-
-- For RelStorage, if the ``sql_adapter`` is set to ``sqlite3``, then
-  derive a path to the data directory automatically. This can be set
-  at the main part level, the part_opts level, or the
-  part_storage_opts level. Also automatically set ``shared-blob-dir``
-  to true.
-
-- For RelStorage, avoid writing out the deprecated
-  ``cache-local-dir-count`` option.
-
 - RelStorage: The value of ``sql_adapter_extra_args`` is validated to
   be syntactically correct.
 
@@ -39,3 +21,19 @@
 - ZEO: Instead of using ``${buildout:directory}/var/`` and
   ``${buildout:directory}/var/log`` directly, refer
   to ``${deployment:run-directory}`` and ``${deployment:log-directory}``.
+
+
+1.0.0a1 (2019-11-14)
+====================
+
+- Fix relstorage recipe on Python 3. See `issue 8
+  <https://github.com/NextThought/nti.recipes.zodb/issues/8>`_.
+
+- For RelStorage, if the ``sql_adapter`` is set to ``sqlite3``, then
+  derive a path to the data directory automatically. This can be set
+  at the main part level, the part_opts level, or the
+  part_storage_opts level. Also automatically set ``shared-blob-dir``
+  to true.
+
+- For RelStorage, avoid writing out the deprecated
+  ``cache-local-dir-count`` option.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,3 +25,17 @@
 
 - RelStorage: The value of ``sql_adapter_extra_args`` is validated to
   be syntactically correct.
+
+- RelStorage: Support providing a PostgreSQL DSN
+
+- All storages: Change the default to use zlibstorage only to
+  decompress existing records, not to compress new records. Set the
+  ``compress`` option (in this recipe or the ``environment`` recipe)
+  to ``compress`` to turn compression on. Set it to ``decompress`` to
+  explicitly request only decompression, and set it to ``none`` to
+  explicitly disable all compression and decompression. In the future,
+  expect the default to change to ``none``. See `issue 9 <https://github.com/NextThought/nti.recipes.zodb/issues/9>`_.
+
+- ZEO: Instead of using ``${buildout:directory}/var/`` and
+  ``${buildout:directory}/var/log`` directly, refer
+  to ``${deployment:run-directory}`` and ``${deployment:log-directory}``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,3 +22,6 @@
 
 - For RelStorage, avoid writing out the deprecated
   ``cache-local-dir-count`` option.
+
+- RelStorage: The value of ``sql_adapter_extra_args`` is validated to
+  be syntactically correct.

--- a/README.rst
+++ b/README.rst
@@ -4,5 +4,8 @@
 
 Recipes for creating RelStorage and ZEO configurations.
 
+.. image:: https://travis-ci.org/NextThought/nti.recipes.zodb.svg?branch=master
+    :target: https://travis-ci.org/NextThought/nti.recipes.zodb
+
 .. image:: https://coveralls.io/repos/github/NextThought/nti.recipes.zodb/badge.svg?branch=master
    :target: https://coveralls.io/github/NextThought/nti.recipes.zodb?branch=master

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setup(
         'setuptools',
         'zc.buildout',
         'zc.recipe.deployment',
-        'zc.zodbrecipes'
+        'zc.zodbrecipes',
+        'ZConfig', # zc.zodbrecipes also depends on this
     ],
     extras_require={
         'test': TESTS_REQUIRE

--- a/src/nti/recipes/zodb/__init__.py
+++ b/src/nti/recipes/zodb/__init__.py
@@ -8,6 +8,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
+from textwrap import dedent
+
 class MetaRecipe(object):
     # Contains the base methods that are required of a recipe,
     # but which meta-recipes (recipes that write other config sections)
@@ -18,3 +20,99 @@ class MetaRecipe(object):
 
     def update(self):
         "Does nothing."
+
+
+class MultiStorageRecipe(MetaRecipe):
+    # Base recipe for deriving multiple storages
+    # from a single call to this recipe.
+    # All of our work is done during __init__.
+
+    # References to hardcoded paths such as /etc/
+    # come from the standard ``deployment`` section
+
+    # This expands into multiple buildout parts; each part whose
+    # description begins with ``$PART_`` is prefixed with the name
+    # of this part.
+    #
+    # * ``$PART_mkdirs`` creates any needed directories.
+    # * ``zodb_conf`` creates ``/etc/zodb_conf.xml``
+    # * ``zodb_uri_conf`` creates ``/etc/zeo_uris.ini``,
+    #   a configparser formatted file with ZODB uris for each
+    #   configured database. This is the same information as ``zodb_conf.xml``,
+    #   in a different format.
+
+    def __init__(self, buildout, my_name, my_options):
+        self.buildout = buildout
+        self.my_name = my_name
+        self.my_options = my_options
+        # Any directories that need to be created
+        # should be a setting in one of the created parts. They are
+        # addressed here as (part, setting) pairs, and added to a part
+        # that uses the z3c.recipe.mkdir recipe to create them.
+        self._dirs_to_create_refs = set()
+        # Likewise, but referring to settings that define a <zodb>
+        # element as a string.
+        self._zodb_refs = set()
+
+    def create_directory(self, part, setting):
+        self._dirs_to_create_refs.add((part, setting))
+
+    def add_database(self, part, setting):
+        # Adds the ZCML at part:setting to zodb_conf.xml
+        self._zodb_refs.add((part, setting))
+
+    def _derive_related_part_name(self, name):
+        return '%s_%s' % (self.my_name, name)
+
+    @staticmethod
+    def __refs_to_lines(refs, indent=4):
+        return ('\n' + ' ' * indent).join(
+            '${%s:%s}' % ref
+            for ref in refs
+        )
+
+    def _parse(self, text, **kwargs):
+        __traceback_info__ = text, kwargs
+        return self.buildout.parse(dedent(text) % kwargs)
+
+    def _normalized_storage_names(self):
+        return [x.lower() for x in self.my_options['storages'].split()]
+
+    def buildout_add_mkdirs(self):
+        name = self._derive_related_part_name('mkdirs')
+        paths = self.__refs_to_lines(self._dirs_to_create_refs)
+        self._parse("""
+        [%(part_name)s]
+        recipe = z3c.recipe.mkdir
+        mode = 0700
+        paths =
+            %(paths)s
+        """, part_name=name, paths=paths)
+
+    def buildout_add_zodb_conf(self):
+        zcml_names = self.__refs_to_lines(self._zodb_refs, indent=8)
+        self._parse("""
+        [zodb_conf]
+        recipe = collective.recipe.template
+        output = ${deployment:etc-directory}/zodb_conf.xml
+        input = inline:
+                %%import zc.zlibstorage
+                %%import relstorage
+
+                %(zcml_names)s
+        """, zcml_names=zcml_names)
+
+    def buildout_add_zeo_uris(self):
+        uris = [
+            "zconfig://${zodb_conf:output}#%s" % name
+            for name in self._normalized_storage_names()
+        ]
+
+        self._parse("""
+        [zodb_uri_conf]
+        recipe = collective.recipe.template
+        output = ${deployment:etc-directory}/zeo_uris.ini
+        input = inline:
+              [ZODB]
+              uris = %(uris)s
+        """, uris=' '.join(uris))

--- a/src/nti/recipes/zodb/__init__.py
+++ b/src/nti/recipes/zodb/__init__.py
@@ -8,7 +8,12 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from textwrap import dedent
+
+from ._model import ZConfigSection
+from ._model import Ref
+from ._model import ChoiceRef
+from ._model import Part
+from ._model import hyphenated
 
 class MetaRecipe(object):
     # Contains the base methods that are required of a recipe,
@@ -21,6 +26,63 @@ class MetaRecipe(object):
     def update(self):
         "Does nothing."
 
+class filestorage(ZConfigSection):
+
+    path = Ref('dump_dir') / 'data.fs'
+    blob_dir = Ref('blob_dump_dir').hyphenate()
+
+    def __init__(self, _name=None, **kwargs):
+        ZConfigSection.__init__(self, 'filestorage', _name, **kwargs)
+
+class zlibstorage(ZConfigSection):
+
+    def __init__(self, _name, storage):
+        self.storage = storage
+        ZConfigSection.__init__(self, self.__class__.__name__,
+                                _name, storage)
+
+class zodb(ZConfigSection):
+    # Also crucial is the pool-size. Each connection has resources
+    # like a memcache connection, a MySQL connection, and its
+    # in-memory cache. Normally, opening a DB and closing the
+    # connection will create a connection (if needed), then return
+    # it to the pool. However, in the case of multi-databases,
+    # when an object from a secondary database needs to be loaded,
+    # the active connection will request a connection to that
+    # database, and when the active connection is closed, that
+    # secondary connection is also closed: BUT NOT RETURNED TO THE
+    # POOL. Instead, the active (primary) connection keeps a
+    # reference to it that it will use in the future. This has the
+    # effect of driving all secondary pools based on the
+    # efficiency of the primary pool. Thus, the pool-size for
+    # everything except the primary database is essentially
+    # meaningless (if the application always begins by opening
+    # that primary database), but that pool size controls everything.
+
+    # If we're doing XHR-polling, it's not unusual for one gunicorn/gevent
+    # worker to have 30 or 40 polling requests active on it an any
+    # one time. Each of those consumes a connection; if our pool size
+    # is smaller than the number of active requests, we can wind
+    # up thrashing on connections, rapidly opening and closing them.
+    # (Because closing the main connection causes it to be repushed on the pool,
+    # which triggers the pool to shrink in size if need be). Calling
+    # DB.connectionDebugInfo() can show this: connections in the pool
+    # have 'opened' of None, while those in use have a timestamp and the length
+    # of time it's been open.
+    pool_size = hyphenated(60)
+    database_name = Ref('name').hyphenate()
+    cache_size = Ref('cache-size').hyphenate()
+
+    def __init__(self, _name, storage):
+        ZConfigSection.__init__(self, 'zodb', _name, APPEND=storage)
+
+class deployment(object):
+    data = Ref('deployment', 'data-directory')
+    etc = Ref('deployment', 'etc-directory')
+
+class ZodbClientPart(Part):
+    cache_size = hyphenated(100000)
+    name = 'BASE'
 
 class MultiStorageRecipe(MetaRecipe):
     # Base recipe for deriving multiple storages
@@ -55,64 +117,81 @@ class MultiStorageRecipe(MetaRecipe):
         self._zodb_refs = set()
 
     def create_directory(self, part, setting):
-        self._dirs_to_create_refs.add((part, setting))
+        self._dirs_to_create_refs.add(Ref(part, setting))
 
     def add_database(self, part, setting):
         # Adds the ZCML at part:setting to zodb_conf.xml
-        self._zodb_refs.add((part, setting))
+        self._zodb_refs.add(Ref(part, setting))
+
+    def ref(self, part, setting=None):
+        """
+        Return a substitution reference: ${part:setting}.
+
+        If called with only one argument, it is the setting and the part
+        is the current part: ${:setting}
+        """
+        if setting is None:
+            setting = part
+            part = ''
+        return Ref(part, setting)
+
+    def choice_ref(self, section_map, setting):
+        return ChoiceRef(section_map, setting)
 
     def _derive_related_part_name(self, name):
         return '%s_%s' % (self.my_name, name)
 
     @staticmethod
-    def __refs_to_lines(refs, indent=4):
-        return ('\n' + ' ' * indent).join(
-            '${%s:%s}' % ref
+    def __refs_to_lines(refs):
+        return [
+            str(ref)
             for ref in refs
-        )
+        ]
 
-    def _parse(self, text, **kwargs):
-        __traceback_info__ = text, kwargs
-        return self.buildout.parse(dedent(text) % kwargs)
+    def _parse(self, part):
+        __traceback_info__ = part
+        return self.buildout.parse(str(part))
 
     def _normalized_storage_names(self):
         return [x.lower() for x in self.my_options['storages'].split()]
 
-    def buildout_add_mkdirs(self):
-        name = self._derive_related_part_name('mkdirs')
-        paths = self.__refs_to_lines(self._dirs_to_create_refs)
-        self._parse("""
-        [%(part_name)s]
-        recipe = z3c.recipe.mkdir
-        mode = 0700
-        paths =
-            %(paths)s
-        """, part_name=name, paths=paths)
+    def buildout_add_mkdirs(self, name=None):
+        # For historical reasons (compatibility with existing deployments)
+        # allow picking a name for this section instead of automatically choosing.
+        part = Part(
+            name or self._derive_related_part_name('mkdirs'),
+            recipe='z3c.recipe.mkdir',
+            mode='0700',
+            paths=self.__refs_to_lines(self._dirs_to_create_refs))
+        self._parse(part)
 
     def buildout_add_zodb_conf(self):
-        zcml_names = self.__refs_to_lines(self._zodb_refs, indent=8)
-        self._parse("""
-        [zodb_conf]
-        recipe = collective.recipe.template
-        output = ${deployment:etc-directory}/zodb_conf.xml
-        input = inline:
-                %%import zc.zlibstorage
-                %%import relstorage
-
-                %(zcml_names)s
-        """, zcml_names=zcml_names)
+        zcml_names = self.__refs_to_lines(self._zodb_refs)
+        part = Part(
+            'zodb_conf',
+            recipe='collective.recipe.template',
+            output=deployment.etc / 'zodb_conf.xml',
+            input=[
+                'inline:',
+                '%import zc.zlibstorage',
+                '%import relstorage',
+            ] + zcml_names
+        )
+        self._parse(part)
 
     def buildout_add_zeo_uris(self):
-        uris = [
+        uris = ' '.join(
             "zconfig://${zodb_conf:output}#%s" % name
             for name in self._normalized_storage_names()
-        ]
-
-        self._parse("""
-        [zodb_uri_conf]
-        recipe = collective.recipe.template
-        output = ${deployment:etc-directory}/zeo_uris.ini
-        input = inline:
-              [ZODB]
-              uris = %(uris)s
-        """, uris=' '.join(uris))
+        )
+        part = Part(
+            'zodb_uri_conf',
+            recipe='collective.recipe.template',
+            output=deployment.etc / 'zeo_uris.ini',
+            input=[
+                'inline:',
+                '[ZODB]',
+                'uris = ' + uris
+            ],
+        )
+        self._parse(part)

--- a/src/nti/recipes/zodb/_model.py
+++ b/src/nti/recipes/zodb/_model.py
@@ -39,9 +39,13 @@ class _Contained(object):
     __name__ = None
 
 class _Values(_Contained):
+    "A dict-like mapping if string keys to string values."
 
     def __init__(self, values):
         self.values = self._translate(dict(values))
+        self.keys = self.values.keys
+        self.items = self.values.items
+
 
     def _translate(self, kwargs):
         cls = type(self)
@@ -304,6 +308,9 @@ class Ref(_Contained, namedtuple('_SubstititionRef', ('part', 'setting'))):
     def format_for_part(self, _):
         return str(self)
 
+    def __copy__(self):
+        return self
+
     def __add__(self, other):
         """
         Add concatenates the values on the same line.
@@ -326,6 +333,12 @@ class Ref(_Contained, namedtuple('_SubstititionRef', ('part', 'setting'))):
     def hyphenate(self):
         return _HyphenatedRef(self.part, self.setting)
 
+class RelativeRef(Ref):
+    """A reference that will be resolved within the current part."""
+
+    def __new__(cls, setting):
+        # pylint:disable=signature-differs
+        return Ref.__new__(cls, '', setting) # pylint:disable=too-many-function-args
 
 class _HyphenatedRef(Ref):
     __slots__ = ()
@@ -390,6 +403,10 @@ class _CompoundValue(_Contained):
 
 
 class ChoiceRef(_Contained):
+    """
+    References a different section:setting based on looking up the
+    part's name in the section map.
+    """
     __slots__ = ('section_map', 'setting')
 
     def __init__(self, section_map, setting):

--- a/src/nti/recipes/zodb/_model.py
+++ b/src/nti/recipes/zodb/_model.py
@@ -1,0 +1,380 @@
+# -*- coding: utf-8 -*-
+"""
+Building blocks to model a configuration.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from contextlib import contextmanager
+from collections import namedtuple
+from copy import copy
+
+class ValueWriter(object):
+
+    def __init__(self):
+        self._lines = []
+        self._current_indent = ''
+
+    def getvalue(self):
+        return '\n'.join(self._lines)
+
+    @contextmanager
+    def indented(self, by='    '):
+        prev_indent = self._current_indent
+        self._current_indent = prev_indent + by
+        yield self
+        self._current_indent = prev_indent
+
+
+    def begin_line(self, *substrs):
+        self._lines.append(self._current_indent + ''.join(substrs))
+
+    def append(self, *substrs):
+        self._lines[-1] += ''.join(substrs)
+
+class _Contained(object):
+    __parent__ = None
+    __name__ = None
+
+class _Values(_Contained):
+
+    def __init__(self, values):
+        self.values = self._translate(dict(values))
+
+    def _translate(self, kwargs):
+        cls = type(self)
+        values = {}
+        for c in reversed(cls.mro()):
+            local_values = {
+                k: v
+                for k, v in vars(c).items()
+                if not k.startswith('_') and not callable(v)
+            }
+            values.update(local_values)
+        values.update(kwargs)
+
+        # Transform kwargs that had _ back into -
+        keys = list(values)
+        for k in keys:
+            v = values[k]
+            cls_value = getattr(cls, k, None)
+            if getattr(cls_value, 'hyphenated', None) \
+               or getattr(values[k], 'hyphenated', None):
+                values.pop(k)
+                k = k.replace('_', '-')
+            elif getattr(cls_value, 'new_name', None):
+                values.pop(k)
+                k = cls_value.new_name
+            if isinstance(v, _Contained):
+                v = copy(v)
+            else:
+                v = _Const(v)
+            v.__parent__ = self
+            v.__name__ = k
+            values[k] = v
+        return values
+
+    def with_settings(self, **kwargs):
+        new_inst = copy(self)
+        new_inst.values = copy(self.values)
+        new_inst.values.update(kwargs)
+        return new_inst
+
+    def ref(self):
+        return Ref(self.__parent__.__name__, self.__name__)
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+    def __delitem__(self, key):
+        del self.values[key]
+
+    def format_value(self, value):
+        if hasattr(value, 'format_for_part'):
+            value = value.format_for_part(self)
+        elif isinstance(value, bool):
+            value = 'true' if value else 'false'
+        elif isinstance(value, int):
+            value = str(value)
+        return value
+
+    def _write_indented_value(self, io, lines):
+        with io.indented():
+            if hasattr(lines, 'write_to'):
+                lines.write_to(io)
+                return
+
+            for line in lines:
+                if hasattr(line, 'write_to'):
+                    line.write_to(io)
+                else:
+                    line = self.format_value(line)
+                    io.begin_line(line)
+
+    _key_value_sep = ' = '
+    _skip_empty_values = False
+
+    def _write_one(self, io, k, v):
+        v = self.format_value(v)
+        if not v and self._skip_empty_values:
+            return
+        io.begin_line(k, self._key_value_sep)
+
+        if v:
+            if isinstance(v, str):
+                assert '\n' not in v
+                io.append(v)
+            else:
+                # A list of lines.
+                self._write_indented_value(io, v)
+
+    def _write_header(self, io):
+        "Does nothing"
+
+    _write_trailer = _write_header
+
+    def _values_to_write(self):
+        return sorted(self.values.items())
+
+    def _write_values(self, io):
+        for k, v in self._values_to_write():
+            self._write_one(io, k, v)
+
+    def write_to(self, io):
+        self._write_header(io)
+        self._write_values(io)
+        self._write_trailer(io)
+
+    def __str__(self):
+        io = ValueWriter()
+        self.write_to(io)
+        return io.getvalue()
+
+class _NamedValues(_Values):
+
+    class uses_name(object):
+        def __init__(self, template):
+            self.template = template
+
+        def format_for_part(self, part):
+            template = part.format_value(self.template)
+            return template % (part.name,)
+
+    def __init__(self, name, values):
+        # extends is a tuple of named parts we extend.
+        self.name = self.__name__ = name
+        _Values.__init__(self, values)
+
+    def named(self, name):
+        new_inst = self.with_settings()
+        new_inst.name = name
+        return new_inst
+
+    def uses_my_name(self, template):
+        uses = self.uses_name(template)
+        def f(_):
+            the_template = self.format_value(template)
+            return the_template % (self.name,)
+        uses.format_for_part = f
+        return uses
+
+class Part(_NamedValues):
+
+    def __init__(self, _name, extends=(), **kwargs):
+        super(Part, self).__init__(_name, kwargs)
+        self.extends = extends
+
+    def __getitem__(self, key):
+        try:
+            return super(Part, self).__getitem__(key)
+        except KeyError:
+            for extension in self.extends:
+                try:
+                    v = extension[key]
+                except (TypeError, KeyError):
+                    pass
+                else:
+                    v = copy(v)
+                    v.__parent__ = self
+                    return v
+            # On Python 2, if we raised an exception in the
+            # loop, it will overwrite the KeyError we
+            # originally caught, and we could wind up with a TypeError,
+            # which is not what we want.
+            raise KeyError(key)
+
+    def _write_header(self, io):
+        io.begin_line('[', self.name, ']')
+        if self.extends:
+            io.begin_line('<=')
+            extends = [getattr(e, 'name', e) for e in self.extends]
+            self._write_indented_value(io, extends)
+        if 'recipe' in self.values:
+            self._write_one(io, 'recipe', self.values['recipe'])
+
+    def _values_to_write(self):
+        for k, v in super(Part, self)._values_to_write():
+            if k != 'recipe':
+                yield k, v
+
+
+class ZConfigSnippet(_Values):
+    _skip_empty_values = True
+    _key_value_sep = ' '
+    _body_indention = '  '
+
+    def __init__(self, **kwargs):
+        self.trailer = kwargs.pop("APPEND", None)
+        _Values.__init__(self, kwargs)
+
+    def _write_trailer(self, io):
+        __traceback_info__ = self.trailer
+        if self.trailer:
+            with io.indented(self._body_indention):
+                # It's always another snippet or a simple value.
+                if hasattr(self.trailer, 'write_to'):
+                    self.trailer.write_to(io)
+                else:
+                    io.begin_line(self.format_value(self.trailer))
+
+
+class ZConfigSection(_NamedValues, ZConfigSnippet):
+
+    def __init__(self, _section_key, _section_name, *sections, **kwargs):
+        ZConfigSnippet.__init__(self, **kwargs)
+        _NamedValues.__init__(self, _section_key, kwargs)
+        self.values.pop('APPEND', None)
+        self.name = _section_key
+        self.zconfig_name = _section_name
+        self.sections = sections
+
+    def _write_values(self, io):
+        with io.indented(self._body_indention):
+            super(ZConfigSection, self)._write_values(io)
+
+    def _write_header(self, io):
+        io.begin_line('<', self.format_value(self.name))
+        if self.zconfig_name:
+            io.append(' ', self.format_value(self.zconfig_name))
+        io.append('>')
+
+        with io.indented('    '):
+            for section in self.sections:
+                section.write_to(io)
+
+    def _write_trailer(self, io):
+        ZConfigSnippet._write_trailer(self, io)
+        io.begin_line("</",
+                      self.format_value(self.name),
+                      '>')
+
+
+class Ref(_Contained, namedtuple('_SubstititionRef', ('part', 'setting'))):
+
+    def __new__(cls, part, setting=None):
+        if setting is None:
+            setting = part
+            part = ''
+        return super(Ref, cls).__new__(cls, part, setting)
+
+    def __str__(self):
+        return '${%s:%s}' % self
+
+    def format_for_part(self, _):
+        return str(self)
+
+    def __add__(self, other):
+        """
+        Add concatenates the values on the same line.
+        """
+        return _CompoundValue(self, other)
+
+    def __div__(self, other):
+        """
+        Like pathlib, / can be used to join a ref with another
+        ref or string to compute a path value.
+        """
+        return _CompoundValue(self, '/', other)
+
+    def __rdiv__(self, other):
+        return _CompoundValue(other, '/', self)
+
+    __truediv__ = __div__ # Py2
+    __rtruediv__ = __rdiv__ # Py2
+
+    def hyphenate(self):
+        return _HyphenatedRef(self.part, self.setting)
+
+
+class _HyphenatedRef(Ref):
+    __slots__ = ()
+    hyphenated = True
+
+class _Const(_Contained):
+
+    def __init__(self, const):
+        self.const = const
+
+    def lower(self):
+        return self.const.lower()
+
+    def format_for_part(self, part):
+        return part.format_value(self.const)
+
+
+class hyphenated(_Const):
+    hyphenated = True
+
+class renamed(object):
+
+    def __init__(self, new_name):
+        self.new_name = new_name
+
+class _CompoundValue(_Contained):
+    def __init__(self, *values):
+        self._values = values
+
+    def __add__(self, other):
+        v = self._values + (other,)
+        return type(self)(*v)
+
+    def __div__(self, other):
+        v = self._values + ('/', other)
+        return type(self)(*v)
+
+    def __rdiv__(self, other):
+        values = self._values
+        # Careful not to double path seps.
+        if isinstance(self._values[0], str) and self._values[0].startswith('/'):
+            values = (self._values[0][1:],) + self._values[1:]
+
+        v = (other, '/') + values
+        return type(self)(*v)
+
+    __truediv__ = __div__ # Py2
+    __rtruediv__ = __rdiv__
+
+    def format_for_part(self, part):
+        strs = []
+        for v in self._values:
+            strs.append(str(part.format_value(v)))
+        return ''.join(strs)
+
+    def __str__(self):
+        part = Part('<invalid part>')
+        return self.format_for_part(part)
+
+
+
+class ChoiceRef(_Contained):
+    __slots__ = ('section_map', 'setting')
+
+    def __init__(self, section_map, setting):
+        self.section_map = section_map
+        self.setting = setting
+
+    def format_for_part(self, part):
+        section = self.section_map[part.name]
+        return str(Ref(section, self.setting))

--- a/src/nti/recipes/zodb/_model.py
+++ b/src/nti/recipes/zodb/_model.py
@@ -176,14 +176,6 @@ class _NamedValues(_Values):
         new_inst.name = name
         return new_inst
 
-    def uses_my_name(self, template):
-        uses = self.uses_name(template)
-        def f(_):
-            the_template = self.format_value(template)
-            return the_template % (self.name,)
-        uses.format_for_part = f
-        return uses
-
 class Part(_NamedValues):
     """
     A buildout configuration part (or section).

--- a/src/nti/recipes/zodb/tests/test__model.py
+++ b/src/nti/recipes/zodb/tests/test__model.py
@@ -15,6 +15,8 @@ from hamcrest import is_
 
 from .. import _model as model
 
+# pylint:disable=protected-access
+
 class TestPart(unittest.TestCase):
 
     def test_failed_lookup_with_str_extends(self):
@@ -39,6 +41,10 @@ class TestPart(unittest.TestCase):
         part_val = part['key']
         assert_that(part_val.const, is_(42))
 
+    def test_get_default(self):
+        part = model.Part('part')
+        self.assertIs(part.get('no-key', self), self)
+
 
 class TestZConfigSnippet(unittest.TestCase):
 
@@ -58,3 +64,9 @@ class TestRef(unittest.TestCase):
         # the way it is created
         val2 = '/root' / val
         assert_that(str(val2), is_('/root/prefix/${part:setting}'))
+
+
+class TestConst(unittest.TestCase):
+
+    def test_str(self):
+        self.assertEqual(str(model._Const(self)), str(self))

--- a/src/nti/recipes/zodb/tests/test__model.py
+++ b/src/nti/recipes/zodb/tests/test__model.py
@@ -12,8 +12,6 @@ import unittest
 
 from hamcrest import assert_that
 from hamcrest import is_
-from hamcrest import has_key
-from hamcrest import has_entry
 
 from .. import _model as model
 
@@ -29,6 +27,18 @@ class TestPart(unittest.TestCase):
         part = model.Part('part', extends=(base,))
         with self.assertRaises(KeyError):
             operator.itemgetter('key')(part)
+
+    def test_lookup_correct_order(self):
+        # Later items take precedence.
+        first = model.Part('first', key='a string')
+        second = model.Part('second', key=42)
+        # wrapped in a const
+        val = second['key']
+        assert_that(val.const, is_(42))
+        part = model.Part('part', extends=(first, second))
+        part_val = part['key']
+        assert_that(part_val.const, is_(42))
+
 
 class TestZConfigSnippet(unittest.TestCase):
 

--- a/src/nti/recipes/zodb/tests/test__model.py
+++ b/src/nti/recipes/zodb/tests/test__model.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for _model.py.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import operator
+import unittest
+
+from hamcrest import assert_that
+from hamcrest import is_
+from hamcrest import has_key
+from hamcrest import has_entry
+
+from .. import _model as model
+
+class TestPart(unittest.TestCase):
+
+    def test_failed_lookup_with_str_extends(self):
+        part = model.Part('part', extends=('base',))
+        with self.assertRaises(KeyError):
+            operator.itemgetter('key')(part)
+
+    def test_failed_lookup_with_extends(self):
+        base = model.Part('base')
+        part = model.Part('part', extends=(base,))
+        with self.assertRaises(KeyError):
+            operator.itemgetter('key')(part)
+
+class TestZConfigSnippet(unittest.TestCase):
+
+    def test_no_empty_values(self):
+        snip = model.ZConfigSnippet(key='')
+        assert_that(str(snip), is_(''))
+
+class TestRef(unittest.TestCase):
+
+    def test_rdiv(self):
+        ref = model.Ref('part', 'setting')
+        val = '/prefix' / ref
+        assert_that(str(val), is_('/prefix/${part:setting}'))
+
+        # val is now a compound value. It also handles rdiv,
+        # even though it is typically on the RHS simply due to
+        # the way it is created
+        val2 = '/root' / val
+        assert_that(str(val2), is_('/root/prefix/${part:setting}'))

--- a/src/nti/recipes/zodb/tests/test_relstorage.py
+++ b/src/nti/recipes/zodb/tests/test_relstorage.py
@@ -162,74 +162,69 @@ class TestDatabases(unittest.TestCase):
             'sql_adapter': 'sqlite3',
             'write-zodbconvert': 'true',
         })
-
-
-        expected = textwrap.dedent("""\
-            <zodb Users>
-                pool-size 60
-                database-name Users
-                cache-size 100000
-                <zlibstorage Users>
-                <relstorage Users>
-                    blob-dir /data/Users.blobs
-                    shared-blob-dir true
-                    cache-prefix Users
-
-                    commit-lock-timeout 60
-                    cache-local-mb 300
-                    cache-local-dir /caches/data_cache/Users.cache
-
-                    name Users
-                    keep-history false
-                    pack-gc false
-                    <sqlite3>
-                        data-dir /data/relstorages_users_storage/
-
-                    </sqlite3>
-                </relstorage>
-            </zlibstorage>
-            </zodb>
-        """).strip()
+        expected = """\
+<zodb Users>
+  cache-size 100000
+  database-name Users
+  pool-size 60
+  <zlibstorage Users>
+    <relstorage Users>
+        <sqlite3>
+          data-dir /data/relstorages_users_storage
+""" + "  " + """
+        </sqlite3>
+      blob-dir /data/Users.blobs
+      cache-local-dir /caches/data_cache/Users.cache
+      cache-local-mb 300
+      cache-prefix Users
+      commit-lock-timeout 60
+      keep-history false
+      name Users
+      pack-gc false
+      shared-blob-dir true
+    </relstorage>
+</zlibstorage>
+</zodb>"""
         self.assertEqual(
             buildout['relstorages_users_storage']['client_zcml'],
             expected)
-
         expected = """\
-            <zodb Sessions>
-                pool-size 60
-                database-name Sessions
-                cache-size 100000
-                <zlibstorage Sessions>
-                <relstorage Sessions>
-                    blob-dir /data/Sessions.blobs
-                    shared-blob-dir true
-                    cache-prefix Sessions
-
-                    commit-lock-timeout 60
-                    cache-local-mb 300
-                    cache-local-dir /caches/data_cache/Sessions.cache
-
-                    name Sessions
-                    keep-history false
-                    pack-gc true
-                    <sqlite3>
-                        data-dir /data/relstorages_sessions_storage/
-                        driver gevent sqlite
-                        <pragmas>
-                           synchronous off
-                        </pragmas>
-                    </sqlite3>
-                </relstorage>
-            </zlibstorage>
-            </zodb>
+<zodb Sessions>
+  cache-size 100000
+  database-name Sessions
+  pool-size 60
+  <zlibstorage Sessions>
+    <relstorage Sessions>
+            <sqlite3>
+            data-dir /data/relstorages_sessions_storage
+              driver gevent sqlite
+              <pragmas>
+               synchronous off
+              </pragmas>
+            </sqlite3>
+        blob-dir /data/Sessions.blobs
+        cache-local-dir /caches/data_cache/Sessions.cache
+        cache-local-mb 300
+        cache-prefix Sessions
+        commit-lock-timeout 60
+        keep-history false
+        name Sessions
+        pack-gc true
+        shared-blob-dir true
+    </relstorage>
+</zlibstorage>
+</zodb>
         """
+
         self.assertEqual(
             [x.strip() for x in
              buildout['relstorages_sessions_storage']['client_zcml'].splitlines() if x.strip()],
             [x.strip() for x in expected.splitlines() if x.strip()])
 
         assert_that(buildout['zodb_conf']['input'],
-                    contains_string('data-dir /data/relstorages_sessions_storage/'))
+                    contains_string('data-dir /data/relstorages_sessions_storage'))
 
         assert_that(buildout['sessions_to_relstorage_conf']['input'],
-                    contains_string('data-dir /data/relstorages_sessions_storage/'))
+                    contains_string('data-dir /data/relstorages_sessions_storage'))
+        assert_that(buildout['sessions_from_relstorage_conf']['input'],
+                    contains_string('data-dir /data/relstorages_sessions_storage'))

--- a/src/nti/recipes/zodb/tests/test_zeo.py
+++ b/src/nti/recipes/zodb/tests/test_zeo.py
@@ -8,30 +8,147 @@ __docformat__ = "restructuredtext en"
 
 import unittest
 
-from hamcrest import assert_that
-from hamcrest import contains_string
-
 from nti.recipes.zodb.zeo import Databases
 from . import NoDefaultBuildout
 
 class TestDatabases(unittest.TestCase):
-
+    maxDiff = None
     def test_parse(self):
         # No verification, just sees if it runs
-
         buildout = NoDefaultBuildout()
         buildout['deployment'] = {
             'etc-directory': '/etc',
-            'data-directory': '/data'
+            'data-directory': '/data',
+            'run-directory': '/var',
+            'log-directory': '/var/log',
         }
 
-        Databases(buildout, 'zeo', {'storages': 'Users Users_1 Sessions',
-                                    'pack-gc': 'true'})
+        Databases(buildout, 'zeo',
+                  {'storages': 'Users Users_1 Sessions',
+                   'pack-gc': 'true'})
 
-        #buildout.print_options()
+        expected = """\
+<zodb users_1_client>
+  cache-size 100000
+  database-name users_1_client
+  pool-size 60
+  <zlibstorage>
+      <zeoclient>
+        blob-dir /data/users_1_client.blobs
+        name users_1_client
+        server /var/zeosocket
+        shared-blob-dir true
+        storage 1
+      </zeoclient>
+    compress false
+  </zlibstorage>
+</zodb>"""
+        self.assertEqual(
+            buildout['users_1_client']['client_zcml'],
+            expected)
 
-        assert_that(buildout['users_1_storage']['server_zcml'],
-                    contains_string('pack-gc true'))
+        expected = """\
+%import zc.zlibstorage
+<zeo>
+  address /var/zeosocket
+</zeo>
+<serverzlibstorage 1>
+    <filestorage 1>
+      blob-dir /data/Users.blobs
+      pack-gc true
+      path /data/Users.fs
+    </filestorage>
+  compress false
+</serverzlibstorage>
+<serverzlibstorage 2>
+    <filestorage 2>
+      blob-dir /data/Users_1.blobs
+      pack-gc true
+      path /data/Users_1.fs
+    </filestorage>
+  compress false
+</serverzlibstorage>
+<serverzlibstorage 3>
+    <filestorage 3>
+      blob-dir /data/Sessions.blobs
+      pack-gc true
+      path /data/Sessions.fs
+    </filestorage>
+  compress false
+</serverzlibstorage>
+<eventlog>
+    <logfile>
+      format %(asctime)s %(message)s
+      level DEBUG
+      path /var/log/zeo.log
+    </logfile>
+</eventlog>"""
+        self.assertEqual(
+            buildout['base_zeo']['zeo.conf'],
+            expected
+        )
 
-        for i in range(1, 4):
-            assert_that(buildout['base_zeo']['zeo.conf'], contains_string('<filestorage %d>' % i))
+    def test_parse_no_compress(self):
+        # No verification, just sees if it runs
+        buildout = NoDefaultBuildout()
+        buildout['deployment'] = {
+            'etc-directory': '/etc',
+            'data-directory': '/data',
+            'run-directory': '/var',
+            'log-directory': '/var/log',
+        }
+
+        Databases(buildout, 'zeo', {
+            'storages': 'Users Users_1 Sessions',
+            'pack-gc': 'true',
+            'compress': 'none',
+        })
+        expected = """\
+<zodb users_1_client>
+  cache-size 100000
+  database-name users_1_client
+  pool-size 60
+  <zeoclient>
+    blob-dir /data/users_1_client.blobs
+    name users_1_client
+    server /var/zeosocket
+    shared-blob-dir true
+    storage 1
+  </zeoclient>
+</zodb>"""
+
+        self.assertEqual(
+            buildout['users_1_client']['client_zcml'],
+            expected)
+
+        expected = """\
+<zeo>
+  address /var/zeosocket
+</zeo>
+<filestorage 1>
+  blob-dir /data/Users.blobs
+  pack-gc true
+  path /data/Users.fs
+</filestorage>
+<filestorage 2>
+  blob-dir /data/Users_1.blobs
+  pack-gc true
+  path /data/Users_1.fs
+</filestorage>
+<filestorage 3>
+  blob-dir /data/Sessions.blobs
+  pack-gc true
+  path /data/Sessions.fs
+</filestorage>
+<eventlog>
+    <logfile>
+      format %(asctime)s %(message)s
+      level DEBUG
+      path /var/log/zeo.log
+    </logfile>
+</eventlog>"""
+
+        self.assertEqual(
+            buildout['base_zeo']['zeo.conf'],
+            expected
+        )

--- a/src/nti/recipes/zodb/tests/test_zeo.py
+++ b/src/nti/recipes/zodb/tests/test_zeo.py
@@ -32,3 +32,6 @@ class TestDatabases(unittest.TestCase):
 
         assert_that(buildout['users_1_storage']['server_zcml'],
                     contains_string('pack-gc true'))
+
+        for i in range(1, 4):
+            assert_that(buildout['base_zeo']['zeo.conf'], contains_string('<filestorage %d>' % i))

--- a/src/nti/recipes/zodb/zeo.py
+++ b/src/nti/recipes/zodb/zeo.py
@@ -10,75 +10,78 @@ from __future__ import absolute_import
 from __future__ import division
 
 from . import MultiStorageRecipe
+from . import deployment
+from . import filestorage
+from . import zlibstorage
+from . import ZodbClientPart
+from . import zodb
+
+from ._model import hyphenated
+from ._model import Part
+from ._model import Ref
+from ._model import ZConfigSection
+from ._model import renamed
 
 logger = __import__('logging').getLogger(__name__)
 
 
-_base_storage = """
-[base_storage]
-name = BASE
-number = 0
-data_dir = ${deployment:data-directory}
-blob_dir = ${:data_dir}/${:name}.blobs
-data_file = ${:data_dir}/${:name}.fs
-pack-gc = false
-server_zcml =
-        <serverzlibstorage ${:number}>
-            <filestorage ${:number}>
-                path ${:data_file}
-                blob-dir ${:blob_dir}
-                pack-gc ${:pack-gc}
-            </filestorage>
-        </serverzlibstorage>
+class serverzlibstorage(zlibstorage):
+    pass
 
-"""
+
+class BaseStoragePart(Part):
+    name = 'BASE'
+    number = 0
+    data_dir = deployment.data
+    blob_dir = Ref('data_dir') / Ref('name') + '.blobs'
+    data_file = Ref('data_dir') / Ref('name') + '.fs'
+    pack_gc = hyphenated(False)
+    server_zcml = serverzlibstorage(
+        Ref('number'),
+        filestorage(
+            Ref('number'),
+            path=Ref('data_file'),
+            blob_dir=Ref("blob_dir"),
+            pack_gc=Ref("pack-gc").hyphenate()
+        )
+    )
+
 # client and storage have to be separate to avoid a dep loop
-_base_client = """
-[base_client]
-<= base_storage
-pool_size = 7
-cache-size = 75000
-name = BASE
-client_zcml =
-        <zodb ${:name}>
-            pool-size ${:pool_size}
-            database-name ${:name}
-            cache-size ${:cache-size}
-            <zlibstorage>
-                <zeoclient>
-                    server ${base_zeo:clientPipe}
-                    shared-blob-dir True
-                    blob-dir ${:blob_dir}
-                    storage 1
-                    name ${:name}
-                </zeoclient>
-            </zlibstorage>
-        </zodb>
-"""
 
-_zeo = """
-[base_zeo]
-name = %s
-recipe = zc.zodbrecipes:server
-clientPipe = ${buildout:directory}/var/zeosocket
-logFile = ${buildout:directory}/var/log/zeo.log
-zeo.conf =
-        %%import zc.zlibstorage
-        <zeo>
-            address ${:clientPipe}
-        </zeo>
+class BaseClientPart(ZodbClientPart):
+    client_zcml = None
 
-        %s
+class zeoclient(ZConfigSection):
+    def __init__(self, **kwargs):
+        ZConfigSection.__init__(self, 'zeoclient', None, **kwargs)
 
-        <eventlog>
-            <logfile>
-                path ${:logFile}
-                format %%(asctime)s %%(message)s
-                level DEBUG
-            </logfile>
-        </eventlog>
-deployment = deployment
-"""
+class zeo(ZConfigSection):
+    def __init__(self, address):
+        ZConfigSection.__init__(
+            self, 'zeo', None,
+            address=address
+        )
+
+class eventlog(ZConfigSection):
+    def __init__(self):
+        logfile = ZConfigSection(
+            'logfile', None,
+            path=Ref('logFile'),
+            format="%(asctime)s %(message)s",
+            level='DEBUG',
+        )
+        ZConfigSection.__init__(
+            self,
+            'eventlog', None, logfile
+        )
+
+class BaseZeoPart(Part):
+    name = None
+    recipe = 'zc.zodbrecipes:server'
+    clientPipe = Ref('buildout', 'directory') / 'var' / 'zeosocket'
+    logFile = Ref('buildout', 'directory') / 'var' / 'log' / 'zeo.log'
+    zeoConf = renamed('zeo.conf')
+    deployment = 'deployment'
 
 class Databases(MultiStorageRecipe):
 
@@ -88,9 +91,28 @@ class Databases(MultiStorageRecipe):
         zeo_name = options.get('name', 'Dataserver')
 
         # Order matters
-        buildout.parse(_base_storage)
+        base_storage_part = BaseStoragePart(self._derive_related_part_name('base_storage'))
+        self._parse(base_storage_part)
 
+        base_client_part = BaseClientPart(
+            self._derive_related_part_name('base_client'),
+            extends=(base_storage_part,),
+            client_zcml=zodb(
+                Ref('name'),
+                zlibstorage(
+                    None,
+                    zeoclient(
+                        server=BaseZeoPart.clientPipe,
+                        shared_blob_dir=hyphenated(True),
+                        blob_dir=hyphenated(self.ref('blob_dir')),
+                        storage=1,
+                        name=self.ref('name'),
+                    )
+                )
+            )
+        )
 
+        self._parse(base_client_part)
         server_zcml_names = []
         zodb_file_uris = []
         client_parts = []
@@ -107,38 +129,42 @@ class Databases(MultiStorageRecipe):
         for i, storage in enumerate(storages):
             # storages begin at 1
             i = i + 1
-            storage_part_name = storage.lower() + '_storage'
-            buildout.parse("""
-            [%s]
-            <= base_storage
-            name = %s
-            number = %d
-            pack-gc = %s
-            """ % (storage_part_name, storage, i, options.get('pack-gc', 'false')))
+            storage_part = Part(
+                storage.lower() + '_storage',
+                extends=(base_storage_part,),
+                name=storage,
+                number=i,
+                pack_gc=hyphenated(options.get('pack-gc', False))
+            )
+            self._parse(storage_part)
 
-            client_part_name = storage.lower() + '_client'
-            client_parts.append(("""
-            [%s]
-            <= %s
-               base_client
-            name = %s
-            """ % (client_part_name, storage_part_name, storage),
-                                 client_part_name))
+            client_part = Part(
+                storage.lower() + '_client',
+                extends=(storage_part, base_client_part),
+                name=storage.lower() + '_client',
+            )
+            client_parts.append(client_part)
 
-            self.create_directory(storage_part_name, 'blob_dir')
-            self.add_database(client_part_name, 'client_zcml')
+            self.create_directory(storage_part.name, 'blob_dir')
+            self.add_database(client_part.name, 'client_zcml')
 
-            server_zcml_names.append("${%s:server_zcml}" % storage_part_name)
+            server_zcml_names.append(storage_part['server_zcml'].ref())
+            zodb_file_uris.append(base_file_uri % {'part': client_part.name})
 
+        base_zeo_part = BaseZeoPart(
+            'base_zeo',
+            name=zeo_name,
+            zeoConf=[
+                '%import zc.zlibstorage',
+                zeo(self.ref('clientPipe')),
+            ] + server_zcml_names + [
+                eventlog(),
+            ],
+        )
 
+        self._parse(base_zeo_part)
 
-            zodb_file_uris.append(base_file_uri % {'part': client_part_name})
-
-        # Indents must match or we get parsing errors, hence
-        # the tabs
-        buildout.parse(_zeo % (zeo_name, '\n        '.join(server_zcml_names)))
-        buildout.parse(_base_client)
-        for client, _part_name in client_parts:
+        for client in client_parts:
             # We'd like for users to be able to overdide
             # our settings in their default.cfg, like they can
             # with normal sections. This is a problem for a few reasons.
@@ -152,19 +178,20 @@ class Databases(MultiStorageRecipe):
             # and force them to all be the same for all storages)
             # For now, make it cause the parse error if attempted so
             # people don't expect it to work.
-
-            buildout.parse(client)
+            self._parse(client)
 
         self.buildout_add_zodb_conf()
         self.buildout_add_zeo_uris()
 
-        buildout.parse("""
-        [zodb_direct_file_uris_conf]
-        recipe = collective.recipe.template
-        output = ${deployment:etc-directory}/zodb_file_uris.ini
-        input = inline:
-              [ZODB]
-              uris = %s
-        """ % ' '.join(zodb_file_uris))
+        self._parse(Part(
+            'zodb_direct_file_uris_conf',
+            recipe='collective.recipe.template',
+            output=deployment.etc / 'zodb_file_uris.ini',
+            input=[
+                'inline:',
+                '[ZODB]',
+                'uris = %s' % ' '.join(zodb_file_uris)
+            ]
+        ))
 
         self.buildout_add_mkdirs()


### PR DESCRIPTION
This lets us share more between ZEO and RelStorage configurations. It's also one step before being able to easily wrap or not wrap and configure compression with zlibstorage for #9.