### PR TITLE
Make more settings configurable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@
   ``${buildout:directory}/var/log`` directly, refer
   to ``${deployment:run-directory}`` and ``${deployment:log-directory}``.
 
+- All storages: Make previously hard-coded values configurable. This
+  includes ``pool-size`` (``pool_size``), ``commit-lock-timeout``
+  (``commit_lock_timeout_``) and ``cache-size`` (``cache_size``).
+  These values can be set in the recipe, in the ``_opts`` section, or
+  in the ``_opts`` section for a particular storage.
 
 1.0.0a1 (2019-11-14)
 ====================

--- a/src/nti/recipes/zodb/relstorage.py
+++ b/src/nti/recipes/zodb/relstorage.py
@@ -20,6 +20,7 @@ from ._model import ZConfigSnippet
 from ._model import Ref as SubstVar
 from ._model import RelativeRef as LocalSubstVar
 from ._model import hyphenated
+from ._model import Default
 
 from . import MultiStorageRecipe
 from . import filestorage
@@ -67,7 +68,7 @@ class BaseStoragePart(ZodbClientPart):
     cache_local_dir = hyphenated(None)
     cache_local_mb = hyphenated(None)
 
-    commit_lock_timeout = 60
+    commit_lock_timeout = Default(60)
     data_dir = SubstVar('deployment', 'data-directory')
     dump_dir = LocalSubstVar('data_dir') / 'relstorage_dump' / LocalSubstVar('dump_name')
     dump_name = LocalSubstVar('name')
@@ -88,7 +89,7 @@ class BaseStoragePart(ZodbClientPart):
     sql_adapter_extra_args = None
 
 
-def _ZConfig_write_to(config, writer):
+def _ZConfig_write_to(config, writer, part):
     writer.begin_line("# This comment preserves whitespace")
     indent = writer.current_indent * 2 + '  '
     for line in config.__str__(indent).splitlines():
@@ -200,12 +201,13 @@ class Databases(MultiStorageRecipe):
             # in precedence order
             other_bases_list = [
                 base_storage_part,
+                buildout.get(name + '_opts_base'),
                 buildout.get(name + '_opts'),
                 buildout.get(part_name + '_opts')
             ]
             part = Part(
                 part_name,
-                extends=tuple(base for base in other_bases_list if base),
+                extends=other_bases_list,
                 name=storage,
             )
 

--- a/src/nti/recipes/zodb/tests/__init__.py
+++ b/src/nti/recipes/zodb/tests/__init__.py
@@ -19,3 +19,25 @@ class NoDefaultBuildout(zc.buildout.testing.Buildout):
 
     def __delitem__(self, key):
         raise NotImplementedError('__delitem__')
+
+
+def default_buildout(default_sections=None, **extra_options):
+    # You CANNOT make a change to a section after it's constructed
+    # here and expect sections that later extend it to see the change. The original
+    # raw data is cached in a few places.
+    extra_options = extra_options or {}
+    buildout = NoDefaultBuildout()
+    sections = dict(
+        deployment={
+            'etc-directory': '/etc',
+            'data-directory': '/data',
+            'cache-directory': '/caches',
+            'run-directory': '/var',
+            'log-directory': '/var/log',
+        },
+        **(default_sections or {})
+    )
+    for k in sections:
+        sections[k].update(extra_options.get(k, {}))
+        buildout[k] = sections[k]
+    return buildout

--- a/src/nti/recipes/zodb/zeo.py
+++ b/src/nti/recipes/zodb/zeo.py
@@ -128,19 +128,37 @@ class Databases(MultiStorageRecipe):
         for i, storage in enumerate(storages):
             # storages begin at 1
             i = i + 1
+            storage_part_name = storage.lower() + '_storage'
+            storage_part_extends = [
+                base_storage_part,
+                buildout.get(name + '_opts_base'),
+                buildout.get(name + '_opts'),
+                buildout.get(storage_part_name + '_opts'),
+            ]
             storage_part = Part(
-                storage.lower() + '_storage',
-                extends=(base_storage_part,),
+                storage_part_name,
+                extends=storage_part_extends,
                 name=storage,
                 number=i,
                 pack_gc=hyphenated(options.get('pack-gc', False))
             )
             self._parse(storage_part)
 
+            client_part_name = storage.lower() + '_client'
+            client_part_extends = [
+                storage_part,
+                base_client_part,
+                # We have to put these in the list again so they get
+                # the desired (high) precedence.
+                buildout.get(name + '_opts_base'),
+                buildout.get(name + '_opts'),
+                buildout.get(storage_part_name + '_opts'),
+                buildout.get(client_part_name + '_opts'),
+            ]
             client_part = Part(
-                storage.lower() + '_client',
-                extends=(storage_part, base_client_part),
-                name=storage.lower() + '_client',
+                client_part_name,
+                extends=client_part_extends,
+                name=client_part_name
             )
             client_parts.append(client_part)
 


### PR DESCRIPTION
 Make previously hard-coded values configurable. This  includes `pool-size` (`pool_size`), `commit-lock-timeout`  (`commit_lock_timeout`) and `cache-size` (`cache_size`).

These values can be set in the recipe, in the `_opts` section, or in the _opts section for a particular storage.

I didn't see anything else hardcoded, though there are still some possible options that just aren't exposed.

Fixes #12 