### PR TITLE
 RelStorage PostgreSQL: Automatically use a correct DSN.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,11 @@
   These values can be set in the recipe, in the ``_opts`` section, or
   in the ``_opts`` section for a particular storage.
 
+- RelStorage PostgreSQL: Automatically use a correct DSN based on the
+  configured host, port, dbname and password if no ``dsn`` setting is
+  specified. Previously it was complex to specify a DSN using
+  configurable values.
+
 1.0.0a1 (2019-11-14)
 ====================
 

--- a/src/nti/recipes/zodb/_model.py
+++ b/src/nti/recipes/zodb/_model.py
@@ -371,6 +371,11 @@ class _Const(_Contained):
     def __init__(self, const):
         self.const = const
 
+    def __bool__(self):
+        return self.const is not None
+
+    __nonzero__ = __bool__
+
     def lower(self):
         return self.const.lower()
 


### PR DESCRIPTION
It is based on the configured host, port, dbname and password if no ``dsn`` setting is specified. Previously it was complex to specify a DSN using configurable values. (And I didn't want to document that 😉 )